### PR TITLE
Target a new tab for "Edit This Page" link

### DIFF
--- a/_layouts/default_toc.html
+++ b/_layouts/default_toc.html
@@ -21,7 +21,7 @@ a page with path "/reference/faq.md" will use `_data/reference.yaml`, etc.
                             </div>
                             <div class="col-md-9">
                                 <div class="edit-this-page">
-                                    <a href="{{site.github.repository_url}}/edit/{{site.github.branch}}/{{page.path}}">
+                                    <a href="{{site.github.repository_url}}/edit/{{site.github.branch}}/{{page.path}}" target="_blank">
                                         <i class="fab fa-github"></i>
                                         Edit This Page
                                     </a>


### PR DESCRIPTION
When clicking the "Edit This Page" link, I'd rather open then editor in a new window.  That way I can suggest a change and continue reading without using back-navigation.